### PR TITLE
added windows compatability by fixing path issues in utils.lua

### DIFF
--- a/lua/epub/utils.lua
+++ b/lua/epub/utils.lua
@@ -7,6 +7,13 @@ local M = {}
 M.unzip = function(epub_path, output_dir)
 	-- Ensure the output directory exists
 	vim.fn.mkdir(output_dir, "p")
+
+	-- Normalize Windows paths: replace backslashes with slashes and remove trailing slash
+	if jit and jit.os == "Windows" then
+		epub_path = epub_path:gsub("\\", "/")
+		output_dir = output_dir:gsub("\\", "/"):gsub("/$", "") -- remove trailing slash
+	end
+
 	-- Construct the unzip command
 	local cmd = string.format("unzip -o %s -d %s 2>&1", vim.fn.shellescape(epub_path), vim.fn.shellescape(output_dir))
 


### PR DESCRIPTION
There was some kind of issue when opening an epub in windows through nvim, and it seemed to be a path problem, so I prompted chatgpt which gave this simple solution, and the epub seems to open without any problem.

Further, I don't know if there was an issue before in opening images using `gi`, but they don't open on a certain epub file, but that is an issue for another day.

Since I am on windows, I could not run `run_tests.sh` so please test it before merging (if you plan to do so).
